### PR TITLE
HPC-7627: Switch to using LocalStorage to manage state

### DIFF
--- a/libs/hpc-live/src/lib/live.ts
+++ b/libs/hpc-live/src/lib/live.ts
@@ -114,8 +114,20 @@ export class LiveBrowserClient {
         userManager.signinRedirect({
           state: window.location.href,
         }),
-      logOut: () => userManager.signoutRedirect(),
+      logOut: () =>
+        userManager.signoutRedirect().then(() => userManager.removeUser()),
     };
+
+    // When user logs in/out in a different tab, log in/out in current tab as well
+    window.addEventListener('storage', (e) => {
+      // This is how oidc-client creates its storage keys
+      const keyPart = `user:${this.config.hpcAuthUrl}:${this.config.hpcAuthClientId}`;
+      if (e.key?.indexOf(keyPart) !== -1) {
+        // Reload the window to have new session from different tab applied to current one
+        window.location.reload();
+      }
+    });
+
     if (user) {
       const result = {
         session,


### PR DESCRIPTION
OIDC uses SessionStorage to maintain the user session by default, and SessionStorage is per-tab, which means opening links in new tabs requires re-login.
Switch to using LocalStorage for managing the user session, which allows for sharing between multiple tabs.

Also, when user logs out in one tab, listen for changes in local storage, in order to log them out from all tabs at once.