### PR TITLE
HPC-7628: Display error message when user has no permission to view the cluster forms

### DIFF
--- a/apps/hpc-cdm/src/app/components/operation-cluster-form-assignments-list.tsx
+++ b/apps/hpc-cdm/src/app/components/operation-cluster-form-assignments-list.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MdCheckCircle } from 'react-icons/md';
+import { MdError } from 'react-icons/md';
 
 import { t } from '../../i18n';
 import { C, styled, dataLoader } from '@unocha/hpc-ui';
@@ -51,10 +51,10 @@ const OperationClusterFormAssignmentsList = (props: Props) => {
               )[0]?.forms || [];
             return forms.length === 0 ? (
               <C.ErrorMessage
-                icon={MdCheckCircle}
+                icon={MdError}
                 strings={t.get(
                   lang,
-                  (s) => s.routes.operations.clusters.forms.none
+                  (s) => s.errors.userErrors['access.permissionError']
                 )}
               />
             ) : (

--- a/apps/hpc-cdm/src/i18n/langs/en.json
+++ b/apps/hpc-cdm/src/i18n/langs/en.json
@@ -10,6 +10,10 @@
     "userErrors": {
       "access.userAlreadyInvited": "That user has already been invited, they must log-in to get access",
       "access.userAlreadyAdded": "That user has already been given access",
+      "access.permissionError": {
+        "title": "Forbidden Error",
+        "info": "Insufficient permissions to view resource"
+      },
       "assignment.alreadyFinalized": "The assignment has already been finalised"
     }
   },
@@ -171,13 +175,7 @@
       },
       "clusters": {
         "listHeader": "Clusters in this operation",
-        "settings": "Cluster Settings",
-        "forms": {
-          "none": {
-            "title": "No forms",
-            "info": "No forms have been assigned to this cluster for the current reporting window"
-          }
-        }
+        "settings": "Cluster Settings"
       }
     }
   }

--- a/apps/hpc-cdm/src/i18n/langs/fr.json
+++ b/apps/hpc-cdm/src/i18n/langs/fr.json
@@ -10,6 +10,10 @@
     "userErrors": {
       "access.userAlreadyInvited": "Cet utilisateur a déjà été invité, il doit se connecter pour avoir accès",
       "access.userAlreadyAdded": "Cet utilisateur a déjà reçu l'accès",
+      "access.permissionError": {
+        "title": "Erreur interdite",
+        "info": "Autorisations insuffisantes pour afficher la ressource"
+      },
       "assignment.alreadyFinalized": "La tâche a déjà été accomplie"
     }
   },
@@ -179,13 +183,7 @@
       },
       "clusters": {
         "listHeader": "Clusters dans cette opération",
-        "settings": "Paramètres de cluster",
-        "forms": {
-          "none": {
-            "title": "Pas de formulaires",
-            "info": "Aucun formulaire n'a été attribué à ce cluster pour la fenêtre de rapport actuelle"
-          }
-        }
+        "settings": "Paramètres de cluster"
       }
     }
   }


### PR DESCRIPTION
When a user does not have permission to view the forms of a particular entity (e.g. cluster lead looking at other clusters), display a forbidden access message, which fixes previous behavior where "No forms" message was displayed, as there are forms they're just invisible to the current user.