### PR TITLE
HPC-7710: fix label formatting by relying on transformer

### DIFF
--- a/apps/hpc-cdm/src/app/components/enketo/editable-form.tsx
+++ b/apps/hpc-cdm/src/app/components/enketo/editable-form.tsx
@@ -168,7 +168,6 @@ export const EnketoEditableForm = (props: Props) => {
       data: new Blob([new Uint8Array(f.data)]),
     }));
     const xform = new XForm(form, model, currentData, files, {
-      titlePrefix: reportingWindow.name,
       onDataUpdate: ({ xform }) => {
         setFormTouched(true);
       },

--- a/apps/hpc-cdm/src/app/components/enketo/xform.ts
+++ b/apps/hpc-cdm/src/app/components/enketo/xform.ts
@@ -1,38 +1,8 @@
 import { Form } from 'enketo-core';
 import fileManager from 'enketo-core/src/js/file-manager';
 import $ from 'jquery';
-import marked from 'marked';
 
 import { LANGUAGE_CHOICE, LanguageKey } from '../../../i18n';
-
-const markedHtml = (
-  form: string,
-  titlePrefix?: string
-): JQuery<HTMLElement> => {
-  const html = $(form);
-
-  for (const selector of ['.question-label', '.question > .or-hint']) {
-    $(selector, html).each(function () {
-      const text = $(this).text().replace(/\n/g, '<br />');
-      $(this).html(marked(text));
-    });
-  }
-
-  if (titlePrefix) {
-    const title = $('h3#form-title', html);
-    title.text(`${titlePrefix}: ${title.text()}`);
-  }
-
-  // operation selection must be visible in order for
-  // locations/sublocations to have available options
-  $('[name="/data/Group_IN/Group_INContact/IN_Operation"]', html).each(
-    function () {
-      $(this).attr('data-relevant', 'true()');
-    }
-  );
-
-  return html;
-};
 
 export interface FormFile {
   name: string;
@@ -50,12 +20,11 @@ export default class XForm {
     content: string | null,
     files: FormFile[],
     opts?: {
-      titlePrefix?: string;
       onDataUpdate?: (event: { xform: XForm }) => void;
     }
   ) {
     this.loading = true;
-    const { titlePrefix, onDataUpdate } = opts || {};
+    const { onDataUpdate } = opts || {};
     this.files = files;
 
     fileManager.getFileUrl = async (subject) => {
@@ -70,7 +39,7 @@ export default class XForm {
       return window.URL.createObjectURL(subject);
     };
 
-    $('.container').replaceWith(markedHtml(html, titlePrefix));
+    $('.container').replaceWith(html);
     const formElement = $('#form').find('form').first()[0];
     if (onDataUpdate) {
       formElement.addEventListener(

--- a/apps/hpc-cdm/src/assets/styles/enketo.css
+++ b/apps/hpc-cdm/src/assets/styles/enketo.css
@@ -8154,11 +8154,6 @@ input[type='checkbox']
     }
 }
 
-.enketo .question-label p {
-    display: inline;
-    margin: 0;
-}
-
 .enketo section .disabled {
     display: none !important;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3658,11 +3658,6 @@
       "integrity": "sha512-InCEXJNTv/59yO4VSfuvNrZHt7eeNtWQEgnieIA+mIC+MOWM9arOWG2eQ8Vhk6NbOre6/BidiXhkZYeDY9U35w==",
       "dev": true
     },
-    "@types/marked": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-1.1.0.tgz",
-      "integrity": "sha512-j8XXj6/l9kFvCwMyVqozznqpd/nk80krrW+QiIJN60Uu9gX5Pvn4/qPJ2YngQrR3QREPwmrE1f9/EWKVTFzoEw=="
-    },
     "@types/mime": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
@@ -13258,11 +13253,6 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
-    },
-    "marked": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.1.tgz",
-      "integrity": "sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw=="
     },
     "md5.js": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@types/jquery": "^3.5.1",
-    "@types/marked": "^1.1.0",
     "@types/react-helmet": "^6.1.0",
     "bowser": "^2.11.0",
     "dayjs": "^1.9.1",
@@ -53,7 +52,6 @@
     "fp-ts": "^2.7.1",
     "intl-list-format": "^1.0.3",
     "io-ts": "^2.2.9",
-    "marked": "^1.1.1",
     "oidc-client": "^1.10.1",
     "pm2": "^4.4.0",
     "react": "16.13.1",


### PR DESCRIPTION
Rather than doing our own markdown formatting, rely on the output
from the transformer (which does its own markdown conversion).
This will also result in more consistency with KoboToolbox.