### PR TITLE
chore: update eslint rules to support optional chaining calls

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,13 +29,23 @@
         ]
       }
     ],
-    "@typescript-eslint/no-namespace": "off"
+    "@typescript-eslint/no-namespace": "off",
+    "no-unused-expressions": "off",
+    "@typescript-eslint/no-unused-expressions": [
+      "error",
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": true
+      }
+    ]
   },
   "overrides": [
     {
       "files": ["*.tsx"],
       "rules": {
-        "@typescript-eslint/no-unused-vars": "off"
+        "@typescript-eslint/no-unused-vars": "off",
+        "no-unused-expressions": "off"
       }
     }
   ]

--- a/apps/hpc-cdm/.eslintrc
+++ b/apps/hpc-cdm/.eslintrc
@@ -125,14 +125,6 @@
     ],
     "no-unexpected-multiline": "warn",
     "no-unreachable": "warn",
-    "no-unused-expressions": [
-      "error",
-      {
-        "allowShortCircuit": true,
-        "allowTernary": true,
-        "allowTaggedTemplates": true
-      }
-    ],
     "no-unused-labels": "warn",
     "no-useless-computed-key": "warn",
     "no-useless-concat": "warn",

--- a/libs/hpc-ui/.eslintrc
+++ b/libs/hpc-ui/.eslintrc
@@ -125,14 +125,6 @@
     ],
     "no-unexpected-multiline": "warn",
     "no-unreachable": "warn",
-    "no-unused-expressions": [
-      "error",
-      {
-        "allowShortCircuit": true,
-        "allowTernary": true,
-        "allowTaggedTemplates": true
-      }
-    ],
     "no-unused-labels": "warn",
     "no-useless-computed-key": "warn",
     "no-useless-concat": "warn",


### PR DESCRIPTION
no-unused-expressions doesn't like things like `foo?.()`, but the typescript one supports it.