### PR TITLE
🐛 generate canModifyWhenClean dummy data based on role 

### DIFF
--- a/libs/hpc-dummy/src/lib/dummy.ts
+++ b/libs/hpc-dummy/src/lib/dummy.ts
@@ -217,7 +217,12 @@ export class Dummy {
       state: assignment.state,
       editable: assignment.editable,
       permissions: {
-        canModifyWhenClean: true,
+        canModifyWhenClean: this.userHasAccess([
+          {
+            target: { type: 'global' },
+            role: 'hpc_admin',
+          },
+        ]),
       },
       task: await getAssignmentTask(assignment),
       assignee,


### PR DESCRIPTION
As a quick fix when working on https://github.com/UN-OCHA/hpc_cdm/pull/172 dummy data for permissions.canModifyWhenClean was hardcoded. This change generates the value based on the logged in role, which is more inline with how the endpoint works