### PR TITLE
🔧 OPS-7386: Prefer new url for config.json

### DIFF
--- a/apps/hpc-cdm/src/environments/environment.prod.ts
+++ b/apps/hpc-cdm/src/environments/environment.prod.ts
@@ -3,4 +3,4 @@ import { loadEnvForConfig } from './config-loader';
 
 export { Environment };
 
-export default () => loadEnvForConfig('/config.json');
+export default () => loadEnvForConfig('/config/config.json', '/config.json');


### PR DESCRIPTION
To unify with other apps, we're changing the path of the config file
to /config/config.json. Once these stack changes have been deployed to
production, and the original path 404s, this backup can be removed.

See: https://github.com/UN-OCHA/hpc-apps-stack/pull/724