### PR TITLE
🔧 Don't login to docker for dependabot PRs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Login to Docker
+      if: ${{ github.actor != 'dependabot[bot]' }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Actions triggered by dependabot PRs don't have access to repo secrets,
and so this step of the workflow fails. Given that we don't need images
to be built and pushed for non-release PRs, we can skip this step.