### PR TITLE
Correct path for config in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: hpc-cdm
     hostname: cdm
     volumes:
-      - .env.json:/var/www/config.json
+      - .env.json:/var/www/config/config.json
     networks:
       service:
         aliases:


### PR DESCRIPTION
This incorrect path was causing an error to be displayed when trying to
load CDM using docker-compose up -d