### PR TITLE
OPS-8532: Use `stable-beagle` as nginx image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN npm run remove-unneeded-deps && \
     npm install && \
     npm run build hpc-cdm -- --output-path=/srv/src/dist --configuration=$ENVIRONMENT
 
-FROM public.ecr.aws/unocha/nginx:1.20.1-safe-beagle
+FROM public.ecr.aws/unocha/nginx:stable-beagle
 
 ARG COMMIT_SHA
 ARG TREE_SHA


### PR DESCRIPTION
Alias named "stable" is created to avoid the need for constant updates when a new version of nginx is released. Currently, alias "stable" points to version `1.22.0-beagle`