### PR TITLE
HPC-9035: :globe_with_meridians: Don't bundle entire package.json in CDM

### DIFF
--- a/apps/hpc-cdm/src/app/app.tsx
+++ b/apps/hpc-cdm/src/app/app.tsx
@@ -6,7 +6,6 @@ import 'react-toastify/dist/ReactToastify.css';
 import { BaseStyling, C, styled, dataLoader, dialogs } from '@unocha/hpc-ui';
 
 import env, { Environment } from '../environments/environment';
-import { version as appVersion } from '../../../../package.json';
 import { AppContext, contextFromEnv } from './context';
 import { LANGUAGE_CHOICE, LanguageKey, t } from '../i18n';
 import { Z_INDEX } from './layout';
@@ -83,7 +82,8 @@ export const App = () => {
   const appTitle = (
     <>
       <TitlePrimary>
-        {t.t(lang, (s) => s.components.appTitle.primary)} (v{appVersion})
+        {t.t(lang, (s) => s.components.appTitle.primary)} (v
+        {APP_VERSION})
       </TitlePrimary>
       <TitleSecondary>
         {t.t(lang, (s) => s.components.appTitle.secondary)}

--- a/apps/hpc-cdm/tsconfig.spec.json
+++ b/apps/hpc-cdm/tsconfig.spec.json
@@ -18,6 +18,7 @@
   ],
   "files": [
     "src/app/components/enketo-form/enketo-core.d.ts",
+    "./webpack.globals.d.ts",
     "../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
     "../../node_modules/@nrwl/react/typings/image.d.ts"
   ]

--- a/apps/hpc-cdm/webpack.globals.d.ts
+++ b/apps/hpc-cdm/webpack.globals.d.ts
@@ -1,0 +1,4 @@
+/**
+ * App version number defined in package.json
+ */
+declare const APP_VERSION: string;

--- a/apps/hpc-cdm/webpack.js
+++ b/apps/hpc-cdm/webpack.js
@@ -1,9 +1,24 @@
 /* eslint-disable */
 const path = require('path');
 const upstreamConfig = require('@nrwl/react/plugins/webpack');
+const webpack = require('webpack');
 
 module.exports = (config) => {
   config = upstreamConfig(config);
+
+  /*
+   * To avoid loading version from package.json in application code,
+   * which causes unintentional bundling of entire package.json, we
+   * are injecting a global variable to expose just the app version.
+   *
+   * See HPC-9035
+   */
+  config.plugins ??= [];
+  config.plugins.push(
+    new webpack.DefinePlugin({
+      APP_VERSION: JSON.stringify(require('../../package.json').version),
+    })
+  );
 
   // Override enketo modules
   config.resolve.alias['enketo/dialog'] = path.resolve(


### PR DESCRIPTION
## Describe your changes:
I removed version import on `app.tsx` and created a global variable in webpack that doesn't serve the user the `package.json`

## How can I test the changes?:
You should init the app and test [here](http://localhost:4200/)

Check if the App version is displayed correctly as: v1.4.1 and that bundle size has indeed decreased, since we no longer ship entire `package.json` file.

## TO DO:
Nothing to do, I think all it's completed

## Does any part of this code spark ⭐ joy ⭐?:
No joy can be found in this code :( 