### PR TITLE
HPC-9036 Give unique key prop to list items in CDM

### DIFF
--- a/apps/hpc-cdm/src/app/components/enketo/modals/assignedUsersModal.tsx
+++ b/apps/hpc-cdm/src/app/components/enketo/modals/assignedUsersModal.tsx
@@ -53,8 +53,8 @@ const AssignedUsersModal = (props: Props) => {
       </UserTitle>
 
       <DialogContent id="alert-dialog-description">
-        {assignment.assignedUsers.map((user) => (
-          <UserLink href={`mailto:${user.email}`}>
+        {assignment.assignedUsers.map((user, i) => (
+          <UserLink key={i} href={`mailto:${user.email}`}>
             <AssignedUsersListItem key={user.email}>
               <UserText>{user.name || user.email}</UserText>
               <MdEmail size={20} color={THEME.colors.pallete.orange.normal} />

--- a/apps/hpc-cdm/src/app/components/target-access-management.tsx
+++ b/apps/hpc-cdm/src/app/components/target-access-management.tsx
@@ -79,10 +79,10 @@ export const TargetAccessManagement = (props: Props) => {
             }
           >
             {active.length > 0 ? (
-              active.map((item, i) => {
+              active.map((item) => {
                 return (
                   <C.ListItem
-                    key={i}
+                    key={item.grantee.id}
                     text={item.grantee.name}
                     actions={
                       <>
@@ -170,9 +170,10 @@ export const TargetAccessManagement = (props: Props) => {
             className={CLS.PADDED_LIST}
           >
             {invites.length > 0 ? (
-              invites.map((item, i) => {
+              invites.map((item) => {
                 return (
                   <C.ListItem
+                    key={item.email}
                     text={item.email}
                     secondary={
                       <span>
@@ -274,10 +275,11 @@ export const TargetAccessManagement = (props: Props) => {
             className={CLS.PADDED_LIST}
           >
             {auditLog.length > 0 ? (
-              auditLog.map((item, i) => {
+              auditLog.map((item) => {
                 const m = dayjs(item.date).locale(lang);
                 return (
                   <C.ListItem
+                    key={`${item.actor.id}-${item.grantee.id}-${item.date}`}
                     prefix={m.fromNow()}
                     text={
                       item.roles.length === 0

--- a/apps/hpc-cdm/src/app/pages/operation-clusters.tsx
+++ b/apps/hpc-cdm/src/app/pages/operation-clusters.tsx
@@ -61,8 +61,9 @@ const PageOperationClusters = (props: Props) => {
                     >
                       {clusters
                         .sort((c1, c2) => (c1.name > c2.name ? 1 : -1))
-                        .map((cluster, i) => (
+                        .map((cluster) => (
                           <C.ListItem
+                            key={cluster.id}
                             text={cluster.name}
                             link={paths.operationCluster({
                               operationId: operation.id,

--- a/apps/hpc-cdm/src/app/pages/operations-list.tsx
+++ b/apps/hpc-cdm/src/app/pages/operations-list.tsx
@@ -41,9 +41,9 @@ export default (props: Props) => {
                     .sort((o1, o2) =>
                       o1.name.toLowerCase().localeCompare(o2.name.toLowerCase())
                     )
-                    .map((o, i) => (
+                    .map((o) => (
                       <C.ListItem
-                        key={i}
+                        key={o.id}
                         text={o.name}
                         link={paths.operation(o.id)}
                       />

--- a/libs/hpc-ui/src/lib/components/language-picker.tsx
+++ b/libs/hpc-ui/src/lib/components/language-picker.tsx
@@ -79,6 +79,7 @@ class LanguagePicker<LanguageKey extends string> extends React.Component<
                   <MenuList autoFocusItem={open}>
                     {choice.getLanguages().map(({ key, name }) => (
                       <MenuItem
+                        key={key}
                         onClick={() => {
                           this.setState({ open: false });
                           choice.setLanguage(key);

--- a/libs/hpc-ui/src/lib/components/main-navigation.tsx
+++ b/libs/hpc-ui/src/lib/components/main-navigation.tsx
@@ -185,7 +185,7 @@ export default (props: Props) => {
           return null;
         }
         return (
-          <MUIListItem disablePadding>
+          <MUIListItem disablePadding key={i}>
             <MUIListItemButton href={link.url}>{link.label}</MUIListItemButton>
           </MUIListItem>
         );


### PR DESCRIPTION
## Describe your changes:

I have added `key` prop to list items that currently didn't have it, and also, I have refactored some of the values we pass to `key` prop to use unique IDs where posible. It is best practice to use these IDs if possible and just use they index as a last resource.

[REFERENCE](https://legacy.reactjs.org/docs/lists-and-keys.html)

## How can I test the changes?:
To test this change you can go [HERE](http://localhost:4200/operations/1/clusters) and check that no error is displayed in the console about missing key prop. If you go anywhere in the app, this error should not appear anywhere. (For further links to test please check @Pl217 's Jira ticket where he wrote all the pausible links [HERE](https://humanitarian.atlassian.net/browse/HPC-9036))

## TO DO:

Nothing to do

## Does any part of this code spark ⭐ joy ⭐?:


Well, trying to use the ID of the item instead of the index, I will take that as a little joy
