### PR TITLE
Add new custom codecs

### DIFF
--- a/libs/hpc-data/src/lib/util.ts
+++ b/libs/hpc-data/src/lib/util.ts
@@ -70,6 +70,19 @@ export const INTEGER_ARRAY_FROM_STRING = new t.Type<number[], number[]>(
   t.identity
 );
 
+export const STRING_FROM_SINGLE_ELEMENT_ARRAY = new t.Type<string, string>(
+  'STRING_FROM_SINGLE_ELEMENT_ARRAY',
+  t.string.is,
+  (v, c) => {
+    if (Array.isArray(v) && v.length === 1 && typeof v[0] === 'string') {
+      return t.success(v[0]);
+    }
+
+    return t.failure(v, c);
+  },
+  t.identity
+);
+
 /**
  * Accepts either a boolean, or a string of a boolean.
  */

--- a/libs/hpc-data/src/lib/util.ts
+++ b/libs/hpc-data/src/lib/util.ts
@@ -111,6 +111,18 @@ export const BOOLEAN_FROM_STRING = new t.Type<boolean, boolean>(
   t.identity
 );
 
+export const TRIMMED_STRING = new t.Type<string, string>(
+  'TRIMMED_STRING',
+  t.string.is,
+  (v, c) => {
+    if (typeof v === 'string') {
+      return t.success(v.trim());
+    }
+    return t.failure(v, c);
+  },
+  t.identity
+);
+
 /**
  * A file BLOB
  */

--- a/libs/hpc-data/src/lib/util.ts
+++ b/libs/hpc-data/src/lib/util.ts
@@ -114,6 +114,13 @@ export const BLOB = new t.Type<Blob, Blob>(
   t.identity
 );
 
+export const BUFFER = new t.Type<Buffer, Buffer, any>(
+  'Buffer',
+  (v): v is Buffer => v instanceof Buffer,
+  (v, c) => (v instanceof Buffer ? t.success(v) : t.failure(v, c)),
+  t.identity
+);
+
 /**
  * A file Buffer
  */


### PR DESCRIPTION
This moves `BUFFER` and `STRING_FROM_SINGLE_ELEMENT_ARRAY` custom codecs from hpc_service here, to be reusable, where other custom codecs live. Third codec, `TRIMMED_STRING` is added because it's needed for this PR - https://github.com/UN-OCHA/hpc_service/pull/3420