### PR TITLE
HPC-9578 Add Apollo Client

### DIFF
--- a/apps/hpc-ftsadmin/src/app/components/filters/filter-flows-table.tsx
+++ b/apps/hpc-ftsadmin/src/app/components/filters/filter-flows-table.tsx
@@ -25,7 +25,6 @@ import InfoAlert from '../info-alert';
 interface Props {
   query: Query;
   setQuery: (newQuery: Query) => void;
-  handleAbortController: () => void;
 }
 export interface FlowsFilterValues {
   flowID?: string[];
@@ -94,7 +93,7 @@ const StyledDiv = tw.div`
   gap-x-4
 `;
 export const FilterFlowsTable = (props: Props) => {
-  const { setQuery, query, handleAbortController } = props;
+  const { setQuery, query } = props;
 
   const { lang, env } = useContext(AppContext);
   const environment = env();
@@ -104,15 +103,10 @@ export const FilterFlowsTable = (props: Props) => {
     FLOWS_FILTER_INITIAL_VALUES
   );
   const handleSubmit = (values: FlowsFilterValues) => {
-    const encodedFilters = encodeFilters(values, FLOWS_FILTER_INITIAL_VALUES);
-
-    if (query.filters !== encodedFilters) {
-      handleAbortController();
-    }
     setQuery({
       ...query,
       page: 0,
-      filters: encodedFilters,
+      filters: encodeFilters(values, FLOWS_FILTER_INITIAL_VALUES),
     });
   };
   const handleResetForm = (
@@ -120,16 +114,11 @@ export const FilterFlowsTable = (props: Props) => {
       nextState?: Partial<FormikState<FlowsFilterValues>>
     ) => void
   ) => {
-    const encodedFilters = encodeFilters({}, FLOWS_FILTER_INITIAL_VALUES);
     formikResetForm();
-
-    if (query.filters !== encodedFilters) {
-      handleAbortController();
-    }
     setQuery({
       ...query,
       page: 0,
-      filters: encodedFilters,
+      filters: encodeFilters({}, FLOWS_FILTER_INITIAL_VALUES),
     });
   };
   return (

--- a/apps/hpc-ftsadmin/src/app/components/filters/filter-organization-table.tsx
+++ b/apps/hpc-ftsadmin/src/app/components/filters/filter-organization-table.tsx
@@ -20,6 +20,7 @@ interface Props {
   query: Query;
   setQuery: (newQuery: Query) => void;
   lang: LanguageKey;
+  handleAbortController: () => void;
 }
 export interface OrganizationFilterValues {
   organization?: string;
@@ -46,7 +47,7 @@ const StyledDiv = tw.div`
   gap-x-4
 `;
 export const FilterOrganizationsTable = (props: Props) => {
-  const { environment, setQuery, query, lang } = props;
+  const { environment, setQuery, query, lang, handleAbortController } = props;
   const filters = decodeFilters(
     query.filters,
     ORGANIZATIONS_FILTER_INITIAL_VALUES
@@ -57,10 +58,17 @@ export const FilterOrganizationsTable = (props: Props) => {
   });
 
   const handleSubmit = (values: OrganizationFilterValues) => {
+    const encodedFilters = encodeFilters(
+      values,
+      ORGANIZATIONS_FILTER_INITIAL_VALUES
+    );
+    if (query.filters !== encodedFilters) {
+      handleAbortController();
+    }
     setQuery({
       ...query,
       page: 0,
-      filters: encodeFilters(values, ORGANIZATIONS_FILTER_INITIAL_VALUES),
+      filters: encodedFilters,
     });
   };
   const handleResetForm = (
@@ -68,11 +76,18 @@ export const FilterOrganizationsTable = (props: Props) => {
       nextState?: Partial<FormikState<OrganizationFilterValues>>
     ) => void
   ) => {
+    const encodedFilters = encodeFilters(
+      {},
+      ORGANIZATIONS_FILTER_INITIAL_VALUES
+    );
     formikResetForm();
+    if (query.filters !== encodedFilters) {
+      handleAbortController();
+    }
     setQuery({
       ...query,
       page: 0,
-      filters: encodeFilters({}, ORGANIZATIONS_FILTER_INITIAL_VALUES),
+      filters: encodedFilters,
     });
   };
   return (

--- a/apps/hpc-ftsadmin/src/app/components/filters/filter-pending-flows-table.tsx
+++ b/apps/hpc-ftsadmin/src/app/components/filters/filter-pending-flows-table.tsx
@@ -16,7 +16,6 @@ import {
 interface Props {
   query: Query;
   setQuery: (newQuery: Query) => void;
-  handleAbortController: () => void;
 }
 export interface PendingFlowsFilterValues {
   status?: FormObjectValue | null;
@@ -49,22 +48,15 @@ const StyledDiv = tw.div`
   gap-x-4
 `;
 export const FilterPendingFlowsTable = (props: Props) => {
-  const { setQuery, query, handleAbortController } = props;
+  const { setQuery, query } = props;
   const { lang, env } = useContext(AppContext);
   const environment = env();
 
   const handleSubmit = (values: PendingFlowsFilterValues) => {
-    const encodedFilters = encodeFilters(
-      values,
-      PENDING_FLOWS_FILTER_INITIAL_VALUES
-    );
-    if (query.filters !== encodedFilters) {
-      handleAbortController();
-    }
     setQuery({
       ...query,
       page: 0,
-      filters: encodedFilters,
+      filters: encodeFilters(values, PENDING_FLOWS_FILTER_INITIAL_VALUES),
     });
   };
   const handleResetForm = (
@@ -72,18 +64,11 @@ export const FilterPendingFlowsTable = (props: Props) => {
       nextState?: Partial<FormikState<PendingFlowsFilterValues>>
     ) => void
   ) => {
-    const encodedFilters = encodeFilters(
-      {},
-      PENDING_FLOWS_FILTER_INITIAL_VALUES
-    );
     formikResetForm();
-    if (query.filters !== encodedFilters) {
-      handleAbortController();
-    }
     setQuery({
       ...query,
       page: 0,
-      filters: encodedFilters,
+      filters: encodeFilters({}, PENDING_FLOWS_FILTER_INITIAL_VALUES),
     });
   };
   return (

--- a/apps/hpc-ftsadmin/src/app/components/tables/flows-table.tsx
+++ b/apps/hpc-ftsadmin/src/app/components/tables/flows-table.tsx
@@ -69,7 +69,6 @@ export interface FlowsTableProps {
   rowsPerPageOption: number[];
   query: Query;
   setQuery: (newQuery: Query) => void;
-  abortSignal?: AbortSignal;
   pending?: boolean;
 }
 
@@ -93,7 +92,6 @@ export default function FlowsTable(props: FlowsTableProps) {
       sortField: query.orderBy,
       sortOrder: query.orderDir,
       ...parsedFilters,
-      signal: props.abortSignal,
       prevPageCursor: query.prevPageCursor,
       nextPageCursor: query.nextPageCursor,
     })

--- a/apps/hpc-ftsadmin/src/app/components/tables/keywords-table.tsx
+++ b/apps/hpc-ftsadmin/src/app/components/tables/keywords-table.tsx
@@ -57,6 +57,7 @@ export interface KeywordTableProps {
   headers: TableHeadersProps<KeywordHeaderID>[];
   query: KeywordQuery;
   setQuery: (newQuery: KeywordQuery) => void;
+  abortSignal: AbortSignal;
 }
 
 /**
@@ -250,7 +251,7 @@ export default function KeywordTable(props: KeywordTableProps) {
   const [openSettings, setOpenSettings] = useState(false);
   const [entityEdited, setEntityEdited] = useState(false);
   const state = dataLoader([entityEdited], () =>
-    env.model.categories.getKeywords()
+    env.model.categories.getKeywords(props.abortSignal)
   );
   const [errorUpdate, setErrorUpdate] = useState<{
     code: keyof Strings['components']['keywordTable']['errors'];

--- a/apps/hpc-ftsadmin/src/app/components/tables/organizations-table.tsx
+++ b/apps/hpc-ftsadmin/src/app/components/tables/organizations-table.tsx
@@ -62,6 +62,7 @@ export interface OrganizationTableProps {
   rowsPerPageOption: number[];
   query: Query;
   setQuery: (newQuery: Query) => void;
+  abortSignal: AbortSignal;
 }
 
 export default function OrganizationTable(props: OrganizationTableProps) {
@@ -87,6 +88,7 @@ export default function OrganizationTable(props: OrganizationTableProps) {
         offset: query.page * query.rowsPerPage,
         orderBy: query.orderBy,
         orderDir: query.orderDir,
+        signal: props.abortSignal,
         ...parseOrganizationFilters(parsedFilters).search,
       },
     })

--- a/apps/hpc-ftsadmin/src/app/pages/flows/flows-list.tsx
+++ b/apps/hpc-ftsadmin/src/app/pages/flows/flows-list.tsx
@@ -23,7 +23,6 @@ import FlowsTable, {
 import FilterFlowsTable, {
   FLOWS_FILTER_INITIAL_VALUES,
 } from '../../components/filters/filter-flows-table';
-import { useCallback, useEffect, useRef } from 'react';
 
 interface Props {
   className?: string;
@@ -39,18 +38,6 @@ const LandingContainer = tw.div`
 `;
 export default (props: Props) => {
   const rowsPerPageOptions = [10, 25, 50, 100];
-  const abortControllerRef = useRef<AbortController>(new AbortController());
-
-  const handleAbortController = useCallback(() => {
-    abortControllerRef.current.abort();
-    abortControllerRef.current = new AbortController();
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      abortControllerRef.current.abort();
-    };
-  }, []);
 
   const [query, setQuery] = useQueryParams({
     page: withDefault(NumberParam, 0),
@@ -94,7 +81,6 @@ export default (props: Props) => {
     initialValues: FLOWS_FILTER_INITIAL_VALUES,
     query: query,
     setQuery: setQuery,
-    abortSignal: abortControllerRef.current.signal,
   };
 
   return (
@@ -105,11 +91,7 @@ export default (props: Props) => {
         >
           <PageMeta title={[t.t(lang, (s) => s.routes.flows.title)]} />
           <Container>
-            <FilterFlowsTable
-              setQuery={setQuery}
-              query={query}
-              handleAbortController={handleAbortController}
-            />
+            <FilterFlowsTable setQuery={setQuery} query={query} />
             <LandingContainer>
               <C.PageTitle>
                 {t.t(lang, (s) => s.routes.flows.title)}

--- a/apps/hpc-ftsadmin/src/app/pages/flows/pending-flows-list.tsx
+++ b/apps/hpc-ftsadmin/src/app/pages/flows/pending-flows-list.tsx
@@ -22,7 +22,6 @@ import {
 import FlowsTable, {
   FlowsTableProps,
 } from '../../components/tables/flows-table';
-import { useCallback, useEffect, useRef } from 'react';
 
 interface Props {
   className?: string;
@@ -35,8 +34,6 @@ const LandingContainer = tw.div`
 `;
 
 export default (props: Props) => {
-  const abortControllerRef = useRef<AbortController>(new AbortController());
-
   const [query, setQuery] = useQueryParams({
     page: withDefault(NumberParam, 0),
     rowsPerPage: withDefault(
@@ -70,17 +67,6 @@ export default (props: Props) => {
     nextPageCursor: withDefault(NumberParam, 0),
   });
 
-  const handleAbortController = useCallback(() => {
-    abortControllerRef.current.abort();
-    abortControllerRef.current = new AbortController();
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      abortControllerRef.current.abort();
-    };
-  }, []);
-
   const pendingFlowsTableProps: FlowsTableProps = {
     headers: DEFAULT_FLOW_TABLE_HEADERS,
     initialValues: PENDING_FLOWS_FILTER_INITIAL_VALUES,
@@ -88,7 +74,6 @@ export default (props: Props) => {
     query: query,
     setQuery: setQuery,
     pending: true,
-    abortSignal: abortControllerRef.current.signal,
   };
 
   return (
@@ -99,11 +84,7 @@ export default (props: Props) => {
         >
           <PageMeta title={[t.t(lang, (s) => s.routes.flows.title)]} />
           <Container>
-            <FilterPendingFlowsTable
-              setQuery={setQuery}
-              query={query}
-              handleAbortController={handleAbortController}
-            />
+            <FilterPendingFlowsTable setQuery={setQuery} query={query} />
             <LandingContainer>
               <C.PageTitle>
                 {t.t(lang, (s) => s.routes.pendingFlows.title)}

--- a/apps/hpc-ftsadmin/src/app/pages/keywords/keyword-list.tsx
+++ b/apps/hpc-ftsadmin/src/app/pages/keywords/keyword-list.tsx
@@ -16,6 +16,7 @@ import {
 import KeywordTable, {
   KeywordTableProps,
 } from '../../components/tables/keywords-table';
+import { useCallback, useEffect, useState } from 'react';
 
 interface Props {
   className?: string;
@@ -46,10 +47,35 @@ export default (props: Props) => {
     tableHeaders: withDefault(StringParam, encodeTableHeaders([], 'keywords')),
   });
 
+  const [abortController, setAbortController] = useState<AbortController>(
+    new AbortController()
+  );
+  const handleAbortController = useCallback(() => {
+    // Abort the ongoing requests
+    abortController.abort();
+
+    // Create a new AbortController for the next requests
+    const newAbortController = new AbortController();
+    setAbortController(newAbortController);
+
+    // Perform actions with the updated filter values
+
+    // Pass the new AbortSignal to FlowsTableGraphQL
+    // This can be part of your state or directly passed as a prop
+  }, [abortController]);
+
+  useEffect(() => {
+    return () => {
+      handleAbortController();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const keywordTableProps: KeywordTableProps = {
     headers: DEFAULT_KEYWORD_TABLE_HEADERS,
     query,
     setQuery,
+    abortSignal: abortController.signal,
   };
 
   return (

--- a/apps/hpc-ftsadmin/src/app/pages/organizations/organization-list.tsx
+++ b/apps/hpc-ftsadmin/src/app/pages/organizations/organization-list.tsx
@@ -22,6 +22,7 @@ import OrganizationTable, {
 import FilterOrganizationsTable, {
   ORGANIZATIONS_FILTER_INITIAL_VALUES,
 } from '../../components/filters/filter-organization-table';
+import { useCallback, useEffect, useState } from 'react';
 
 interface Props {
   className?: string;
@@ -35,6 +36,29 @@ const LandingContainer = tw.div`
 `;
 export default (props: Props) => {
   const rowsPerPageOptions = [10, 25, 50, 100];
+  const [abortController, setAbortController] = useState<AbortController>(
+    new AbortController()
+  );
+  const handleAbortController = useCallback(() => {
+    // Abort the ongoing requests
+    abortController.abort();
+
+    // Create a new AbortController for the next requests
+    const newAbortController = new AbortController();
+    setAbortController(newAbortController);
+
+    // Perform actions with the updated filter values
+
+    // Pass the new AbortSignal to FlowsTableGraphQL
+    // This can be part of your state or directly passed as a prop
+  }, [abortController]);
+
+  useEffect(() => {
+    return () => {
+      handleAbortController();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const [query, setQuery] = useQueryParams({
     page: withDefault(NumberParam, 0),
@@ -78,6 +102,7 @@ export default (props: Props) => {
     initialValues: ORGANIZATIONS_FILTER_INITIAL_VALUES,
     query: query,
     setQuery: setQuery,
+    abortSignal: abortController.signal,
   };
 
   const env = getEnv();
@@ -94,6 +119,7 @@ export default (props: Props) => {
               setQuery={setQuery}
               query={query}
               lang={lang}
+              handleAbortController={handleAbortController}
             />
             <LandingContainer>
               <C.PageTitle>

--- a/libs/hpc-data/src/lib/categories.ts
+++ b/libs/hpc-data/src/lib/categories.ts
@@ -1,4 +1,5 @@
 import * as t from 'io-ts';
+import type { AbortSignalType } from './util';
 
 export type CategoryGroup =
   | 'flowType'
@@ -82,7 +83,7 @@ export type MergeKeywordResult = t.TypeOf<typeof MERGE_KEYWORD_RESULT>;
 
 export interface Model {
   getCategories(params: GetCategoriesParams): Promise<GetCategoriesResult>;
-  getKeywords(): Promise<GetKeywordsResult>;
+  getKeywords(abortSignal?: AbortSignalType): Promise<GetKeywordsResult>;
   deleteKeyword(params: DeleteKeywordParams): Promise<DeleteKeywordResult>;
   updateKeyword(params: Keyword): Promise<Category>;
   mergeKeywords(params: MergeKeywordParams): Promise<MergeKeywordResult>;

--- a/libs/hpc-data/src/lib/flows.ts
+++ b/libs/hpc-data/src/lib/flows.ts
@@ -293,13 +293,6 @@ const FLOW_FILTERS = t.partial({
 });
 
 export type FlowFilters = t.TypeOf<typeof FLOW_FILTERS>;
-const AbortSignalType = new t.Type<AbortSignal, AbortSignal, unknown>(
-  'AbortSignal',
-  (input: unknown): input is AbortSignal => input instanceof AbortSignal,
-  (input, context) =>
-    input instanceof AbortSignal ? t.success(input) : t.failure(input, context),
-  t.identity
-);
 
 export const NESTED_FLOW_FILTERS = t.partial({
   reporterRefCode: t.string,
@@ -315,7 +308,6 @@ export const SEARCH_FLOWS_PARAMS = t.partial({
   sortOrder: t.string,
   sortField: t.string,
   ...FLOW_FILTERS.props,
-  signal: AbortSignalType,
 });
 export type SearchFlowsParams = t.TypeOf<typeof SEARCH_FLOWS_PARAMS>;
 

--- a/libs/hpc-data/src/lib/organizations.ts
+++ b/libs/hpc-data/src/lib/organizations.ts
@@ -1,5 +1,6 @@
 import * as t from 'io-ts';
 import { LOCATION_BUILDER } from './locations';
+import { ABORT_SIGNAL } from './util';
 
 const ORGANIZATION_CATEGORY = t.type({
   id: t.number,
@@ -125,6 +126,7 @@ export const SEARCH_ORGANIZATION_PARAMS = t.type({
     orderDir: t.union([t.string, t.null]),
     limit: t.number,
     offset: t.number,
+    signal: ABORT_SIGNAL,
   }),
 });
 export type SearchOrganizationParams = t.TypeOf<

--- a/libs/hpc-data/src/lib/util.ts
+++ b/libs/hpc-data/src/lib/util.ts
@@ -404,3 +404,13 @@ export const VALID_DAYJS_DATE = new t.Type<Dayjs, Dayjs>(
   },
   t.identity
 );
+
+export const ABORT_SIGNAL = new t.Type<AbortSignal, AbortSignal, unknown>(
+  'AbortSignal',
+  (input: unknown): input is AbortSignal => input instanceof AbortSignal,
+  (input, context) =>
+    input instanceof AbortSignal ? t.success(input) : t.failure(input, context),
+  t.identity
+);
+
+export type AbortSignalType = t.TypeOf<typeof ABORT_SIGNAL>;

--- a/libs/hpc-live/src/lib/model.ts
+++ b/libs/hpc-live/src/lib/model.ts
@@ -587,7 +587,7 @@ export class LiveModel implements Model {
           },
           resultType: categories.GET_CATEGORIES_RESULT,
         }),
-      getKeywords: () =>
+      getKeywords: (signal) =>
         this.call({
           pathname: '/v2/category',
           queryParams: {
@@ -595,6 +595,7 @@ export class LiveModel implements Model {
             scopes: 'relatedCount',
           },
           resultType: categories.GET_KEYWORDS_RESULT,
+          signal,
         }),
       deleteKeyword: (params) =>
         this.call({
@@ -754,6 +755,7 @@ export class LiveModel implements Model {
             type: 'json',
             data: params,
           },
+          signal: params.search.signal,
           resultType: organizations.SEARCH_ORGANIZATION_RESULT,
         }),
       getOrganization: (params) =>

--- a/libs/hpc-live/src/lib/utils.ts
+++ b/libs/hpc-live/src/lib/utils.ts
@@ -28,7 +28,7 @@ export const searchFlowsParams = (params: flows.SearchFlowsParams): string => {
         break;
       }
       default: {
-        if (key !== 'signal' && params[key]) {
+        if (params[key]) {
           queryParams += `${key}: ${stringify(params[key])} `;
         }
         break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.9.2",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@apollo/client": "3.11.5",
         "@babel/core": "7.21.4",
         "@babel/preset-env": "7.21.4",
         "@babel/preset-react": "7.18.6",
@@ -133,6 +134,49 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.11.5.tgz",
+      "integrity": "sha512-gmTKgXhYH2Q3VT9vUWChuMy34gfK7n/EEJYc7kXt1GP7678Vz2L0xUlHSMEoPoqit317eamZjXQSyxlpn03lnQ==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.18.0",
+        "prop-types": "^15.7.2",
+        "rehackt": "^0.1.0",
+        "response-iterator": "^0.2.6",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2825,6 +2869,15 @@
       "dev": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "dev": true,
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -6743,6 +6796,54 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -11822,6 +11923,31 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/graphql": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
+      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -16136,6 +16262,30 @@
         "opener": "bin/opener-bin.js"
       }
     },
+    "node_modules/optimism": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.0.tgz",
+      "integrity": "sha512-tGn8+REwLRNFnb9WmcY5IfpOqeX2kpaYJ1s6Ae3mn12AeydLkR3j+jSCmVQFoXqU8D41PAJ1RG1rCRNWmNZVmQ==",
+      "dev": true,
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.4.3",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/optimism/node_modules/@wry/trie": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -17858,6 +18008,24 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/rehackt": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
+      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -17946,6 +18114,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/response-iterator": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/restore-cursor": {
@@ -19307,6 +19484,15 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.10",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.10.tgz",
@@ -19729,6 +19915,18 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/ts-invariant": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ts-jest": {
       "version": "29.1.0",
@@ -20926,6 +21124,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+      "dev": true
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "dev": true,
+      "dependencies": {
+        "zen-observable": "0.8.15"
       }
     },
     "node_modules/zip-stream": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "private": true,
   "devDependencies": {
+    "@apollo/client": "3.11.5",
     "@babel/core": "7.21.4",
     "@babel/preset-env": "7.21.4",
     "@babel/preset-react": "7.18.6",


### PR DESCRIPTION
## Nature of PR

- [ ]  Bug-fix
- [ ]  Hot-fix
- [X]  Feature
- [ ]  Testing
- [ ]  Rewrite
- [ ]  CI
- [ ]  Package update


## Description

Add Apollo client to make calls to GrapQL endpoints. Beside setting up Apollo client I added an `AbortSignal` for calls that are using our REST endpoints, like this when changing of page the petition gets cancelled.

Out of the box Apollo will let us have a cache system, that's why I remove the abort signals from petitions using it, once they are made they will not repeat themselves and they will be accessed form the cache.

Apollo allow use to use their own hooks like `useQuery`, but since we have already implemented in the project our own `dataLoader` I was not sure what would be the best idea. Also, reusing our `dataLoader` makes the implementation easier with less changes.

## How to test changes

To test changes I feel the key places to look are:
1. `model.ts` I added Apollo client here and we should double check that this should be the place where it belongs, if it's not the case we need to see where would that be.
2. Navigate through Flow and Pending Flow pages and play around with searches to verify that the cache policy is no making as return false data.

## TODO:

Maybe we could investigate what else could we do with Apollo Client, there is a TODO comment in the code that we could look into:

> TODO: Dynamically fetch only necessary fields, Ex: if we don't display 'NewMoney' we shouldn't ask for it

And I suppose Apollo offers some kind of solution for this. In any case, if we feel is the case we could open a ticket in the future.