### PR TITLE
HPC-9547:  Add `STRING_ARRAY_FROM_STRING` codec

### DIFF
--- a/libs/hpc-data/src/lib/util.ts
+++ b/libs/hpc-data/src/lib/util.ts
@@ -150,7 +150,7 @@ export const INTEGER_ARRAY_FROM_STRING = new t.Type<number[], number[]>(
         ? t.success(v)
         : t.failure(v, c);
     } else if (typeof v === 'string') {
-      const nums = v.split(',');
+      const nums = v.split(',').filter((n) => n.trim() !== '');
       return nums.every((n) => INTEGER_REGEX.test(n))
         ? t.success(nums.map((n) => parseInt(n)))
         : t.failure(v, c);

--- a/libs/hpc-data/src/lib/util.ts
+++ b/libs/hpc-data/src/lib/util.ts
@@ -161,6 +161,29 @@ export const INTEGER_ARRAY_FROM_STRING = new t.Type<number[], number[]>(
   t.identity
 );
 
+/**
+ * Accepts either an string array, or a string of comma separated strings.
+ */
+export const STRING_ARRAY_FROM_STRING = new t.Type<string[], string[]>(
+  'STRING_ARRAY_FROM_STRING',
+  t.array(t.string).is,
+  (v, c) => {
+    if (Array.isArray(v)) {
+      return v.every((val) => typeof val === 'string')
+        ? t.success(v)
+        : t.failure(v, c);
+    } else if (typeof v === 'string') {
+      const strings = v.split(',').filter((s) => s.trim() !== '');
+      return strings.every((s) => typeof s === 'string')
+        ? t.success(strings)
+        : t.failure(v, c);
+    } else {
+      return t.failure(v, c);
+    }
+  },
+  t.identity
+);
+
 export const STRING_FROM_SINGLE_ELEMENT_ARRAY = new t.Type<string, string>(
   'STRING_FROM_SINGLE_ELEMENT_ARRAY',
   t.string.is,


### PR DESCRIPTION
For commit [d76daf3](https://github.com/UN-OCHA/hpc-cdm/commit/d76daf368933232a857ce8b66f7759299b660b0e) [Improve INTEGER_ARRAY_FROM_STRING to filter empty item], Now it will accept params with empty value like this `?includePlans=` and will return empty array.
It looks like its change will not harm users of `INTEGER_ARRAY_FROM_STRING` codec