### PR TITLE
HPC-9965 Upgrade `react-router-dom` to `react-router` `v7.0.2`

### DIFF
--- a/apps/hpc-cdm/src/app/app.tsx
+++ b/apps/hpc-cdm/src/app/app.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 

--- a/apps/hpc-cdm/src/app/app.tsx
+++ b/apps/hpc-cdm/src/app/app.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Navigate, Route, Routes } from 'react-router';
+import { Outlet } from 'react-router';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
@@ -11,13 +11,8 @@ import { LANGUAGE_CHOICE, LanguageKey, t } from '../i18n';
 import { Z_INDEX } from './layout';
 import * as paths from './paths';
 import PageMeta from './components/page-meta';
-import { RouteParamsValidator } from './components/route-params-validator';
 
-import PageAdmin from './pages/admin';
 import PageNotLoggedIn from './pages/not-logged-in';
-import PageNotFound from './pages/not-found';
-import PageOperationsList from './pages/operations-list';
-import PageOperation from './pages/operation';
 
 const environmentWarning = (env: Environment, lang: LanguageKey) => {
   const warning = env.getDevHeaderWarning(lang);
@@ -143,32 +138,7 @@ export const App = () => {
                             : []),
                         ]}
                       />
-                      <Routes>
-                        <Route
-                          path={paths.home()}
-                          element={<Navigate to={paths.operations()} />}
-                        />
-                        <Route
-                          path={paths.operations()}
-                          element={<PageOperationsList />}
-                        />
-                        <Route
-                          path={paths.operationRoot()}
-                          element={
-                            <RouteParamsValidator
-                              element={<PageOperation />}
-                              routeParam="id"
-                            />
-                          }
-                        />
-                        {canModifyGlobalUserAccess && (
-                          <Route
-                            path={paths.adminRoot()}
-                            element={<PageAdmin />}
-                          />
-                        )}
-                        <Route path={paths.root()} element={<PageNotFound />} />
-                      </Routes>
+                      <Outlet />
                     </LoggedInContainer>
                   ) : (
                     <>

--- a/apps/hpc-cdm/src/app/components/cluster-navigation.tsx
+++ b/apps/hpc-cdm/src/app/components/cluster-navigation.tsx
@@ -6,7 +6,7 @@ import { operations } from '@unocha/hpc-data';
 
 import * as paths from '../paths';
 import { AppContext } from '../context';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 interface Props {
   operation: operations.DetailedOperation;

--- a/apps/hpc-cdm/src/app/components/enketo/formToolbar/StatusChangeButtons.tsx
+++ b/apps/hpc-cdm/src/app/components/enketo/formToolbar/StatusChangeButtons.tsx
@@ -2,7 +2,7 @@ import React, { useContext, Dispatch, SetStateAction } from 'react';
 
 import { styled, C } from '@unocha/hpc-ui';
 import { reportingWindows } from '@unocha/hpc-data';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { AppContext, getEnv } from '../../../context';
 import { t } from '../../../../i18n';
 import { FormStatus } from '../types';

--- a/apps/hpc-cdm/src/app/components/enketo/index.tsx
+++ b/apps/hpc-cdm/src/app/components/enketo/index.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState, useEffect, useRef } from 'react';
 import { reportingWindows, errors } from '@unocha/hpc-data';
 import { styled } from '@unocha/hpc-ui';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import dayjs from '../../../libraries/dayjs';
 

--- a/apps/hpc-cdm/src/app/components/form-assignment-data.tsx
+++ b/apps/hpc-cdm/src/app/components/form-assignment-data.tsx
@@ -3,7 +3,7 @@ import React, { useContext } from 'react';
 import { t } from '../../i18n';
 import { C, dataLoader } from '@unocha/hpc-ui';
 import { reportingWindows } from '@unocha/hpc-data';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { AppContext, getEnv } from '../context';
 import { EnketoEditableForm } from './enketo';

--- a/apps/hpc-cdm/src/app/components/route-params-validator.tsx
+++ b/apps/hpc-cdm/src/app/components/route-params-validator.tsx
@@ -1,6 +1,6 @@
 import { C } from '@unocha/hpc-ui';
 import { useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { t } from '../../i18n';
 import { AppContext } from '../context';
 

--- a/apps/hpc-cdm/src/app/pages/admin.tsx
+++ b/apps/hpc-cdm/src/app/pages/admin.tsx
@@ -12,44 +12,50 @@ import PageMeta from '../components/page-meta';
 const PageAdmin = () => {
   return (
     <AppContext.Consumer>
-      {({ lang }) => (
-        <div className={CLASSES.CONTAINER.CENTERED}>
-          <PageMeta title={[t.t(lang, (s) => s.navigation.admin)]} />
-          <C.SidebarNavigation
-            menu={[
-              {
-                label: t.t(lang, (s) => s.navigation.manageAccess),
-                path: paths.adminAccess(),
-              },
-            ]}
-          >
-            <Routes>
-              <Route
-                path={paths.home()}
-                element={<Navigate to={paths.access()} />}
-              />
-              <Route
-                path={paths.access()}
-                element={
-                  <TargetAccessManagement
-                    target={{
-                      type: 'global',
-                    }}
-                  />
-                }
-              />
-              <Route
-                path={paths.root()}
-                element={
-                  <C.NotFound
-                    strings={t.get(lang, (s) => s.components.notFound)}
-                  />
-                }
-              />
-            </Routes>
-          </C.SidebarNavigation>
-        </div>
-      )}
+      {({ lang, access }) => {
+        const { canModifyGlobalUserAccess } = access().permissions;
+        if (!canModifyGlobalUserAccess) {
+          return <Navigate to={paths.home()} />;
+        }
+        return (
+          <div className={CLASSES.CONTAINER.CENTERED}>
+            <PageMeta title={[t.t(lang, (s) => s.navigation.admin)]} />
+            <C.SidebarNavigation
+              menu={[
+                {
+                  label: t.t(lang, (s) => s.navigation.manageAccess),
+                  path: paths.adminAccess(),
+                },
+              ]}
+            >
+              <Routes>
+                <Route
+                  path={paths.home()}
+                  element={<Navigate to={paths.access()} />}
+                />
+                <Route
+                  path={paths.access()}
+                  element={
+                    <TargetAccessManagement
+                      target={{
+                        type: 'global',
+                      }}
+                    />
+                  }
+                />
+                <Route
+                  path={paths.root()}
+                  element={
+                    <C.NotFound
+                      strings={t.get(lang, (s) => s.components.notFound)}
+                    />
+                  }
+                />
+              </Routes>
+            </C.SidebarNavigation>
+          </div>
+        );
+      }}
     </AppContext.Consumer>
   );
 };

--- a/apps/hpc-cdm/src/app/pages/admin.tsx
+++ b/apps/hpc-cdm/src/app/pages/admin.tsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes } from 'react-router';
 
 import { CLASSES, C } from '@unocha/hpc-ui';
 
+import PageNotFound from '../pages/not-found';
 import { t } from '../../i18n';
 import { AppContext } from '../context';
 import * as paths from '../paths';
@@ -15,7 +16,7 @@ const PageAdmin = () => {
       {({ lang, access }) => {
         const { canModifyGlobalUserAccess } = access().permissions;
         if (!canModifyGlobalUserAccess) {
-          return <Navigate to={paths.home()} />;
+          return <PageNotFound />;
         }
         return (
           <div className={CLASSES.CONTAINER.CENTERED}>

--- a/apps/hpc-cdm/src/app/pages/admin.tsx
+++ b/apps/hpc-cdm/src/app/pages/admin.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { CLASSES, C } from '@unocha/hpc-ui';
 

--- a/apps/hpc-cdm/src/app/pages/operation-cluster-form-assignments.tsx
+++ b/apps/hpc-cdm/src/app/pages/operation-cluster-form-assignments.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes, useParams } from 'react-router-dom';
+import { Route, Routes, useParams } from 'react-router';
 
 import { C, styled } from '@unocha/hpc-ui';
 import { operations } from '@unocha/hpc-data';

--- a/apps/hpc-cdm/src/app/pages/operation-cluster-forms.tsx
+++ b/apps/hpc-cdm/src/app/pages/operation-cluster-forms.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { C, styled } from '@unocha/hpc-ui';
 import { operations } from '@unocha/hpc-data';

--- a/apps/hpc-cdm/src/app/pages/operation-cluster-settings.tsx
+++ b/apps/hpc-cdm/src/app/pages/operation-cluster-settings.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { C } from '@unocha/hpc-ui';
 import { operations } from '@unocha/hpc-data';

--- a/apps/hpc-cdm/src/app/pages/operation-cluster.tsx
+++ b/apps/hpc-cdm/src/app/pages/operation-cluster.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useParams } from 'react-router';
 
 import { C, styled } from '@unocha/hpc-ui';
 import { operations } from '@unocha/hpc-data';

--- a/apps/hpc-cdm/src/app/pages/operation-clusters.tsx
+++ b/apps/hpc-cdm/src/app/pages/operation-clusters.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import { C, styled, dataLoader } from '@unocha/hpc-ui';
 import { operations } from '@unocha/hpc-data';

--- a/apps/hpc-cdm/src/app/pages/operation-form-assignments.tsx
+++ b/apps/hpc-cdm/src/app/pages/operation-form-assignments.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes, useParams } from 'react-router-dom';
+import { Route, Routes, useParams } from 'react-router';
 
 import { t } from '../../i18n';
 import { C, styled } from '@unocha/hpc-ui';

--- a/apps/hpc-cdm/src/app/pages/operation-forms.tsx
+++ b/apps/hpc-cdm/src/app/pages/operation-forms.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { C, combineClasses, styled } from '@unocha/hpc-ui';
 import { operations } from '@unocha/hpc-data';

--- a/apps/hpc-cdm/src/app/pages/operation-settings.tsx
+++ b/apps/hpc-cdm/src/app/pages/operation-settings.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { C } from '@unocha/hpc-ui';
 import { operations } from '@unocha/hpc-data';

--- a/apps/hpc-cdm/src/app/pages/operation.tsx
+++ b/apps/hpc-cdm/src/app/pages/operation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useParams } from 'react-router';
 
 import { CLASSES, C, dataLoader } from '@unocha/hpc-ui';
 

--- a/apps/hpc-cdm/src/app/utils/usePrompt.tsx
+++ b/apps/hpc-cdm/src/app/utils/usePrompt.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useEffect } from 'react';
-import { UNSAFE_NavigationContext as NavigationContext } from 'react-router-dom';
+import { UNSAFE_NavigationContext as NavigationContext } from 'react-router';
 
 function useConfirmExit(confirmExit: () => boolean, when = true) {
   const { navigator } = useContext(NavigationContext);

--- a/apps/hpc-cdm/src/main.tsx
+++ b/apps/hpc-cdm/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import { ThemeProvider } from '@unocha/hpc-ui';
 
 import App from './app/app';
@@ -13,12 +13,7 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 
 root.render(
-  <BrowserRouter
-    future={{
-      v7_startTransition: true,
-      v7_relativeSplatPath: true,
-    }}
-  >
+  <BrowserRouter>
     <ThemeProvider>
       <App />
     </ThemeProvider>

--- a/apps/hpc-cdm/src/main.tsx
+++ b/apps/hpc-cdm/src/main.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router';
+import { createBrowserRouter, Navigate, RouterProvider } from 'react-router';
 import { ThemeProvider } from '@unocha/hpc-ui';
 
 import App from './app/app';
 import './assets/styles/enketo.css';
+import { RouteParamsValidator } from './app/components/route-params-validator';
+import * as paths from './app/paths';
+
+import PageAdmin from './app/pages/admin';
+import PageNotFound from './app/pages/not-found';
+import PageOperationsList from './app/pages/operations-list';
+import PageOperation from './app/pages/operation';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -12,10 +19,30 @@ if (!rootElement) {
 }
 const root = ReactDOM.createRoot(rootElement);
 
-root.render(
-  <BrowserRouter>
-    <ThemeProvider>
-      <App />
-    </ThemeProvider>
-  </BrowserRouter>
-);
+const router = createBrowserRouter([
+  {
+    path: paths.home(),
+    element: (
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    ),
+    children: [
+      { path: paths.home(), element: <Navigate to={paths.operations()} /> },
+      { path: paths.operations(), element: <PageOperationsList /> },
+      {
+        path: paths.operationRoot(),
+        element: (
+          <RouteParamsValidator element={<PageOperation />} routeParam="id" />
+        ),
+      },
+      {
+        path: paths.adminRoot(),
+        element: <PageAdmin />,
+      },
+      { path: paths.root(), element: <PageNotFound /> },
+    ],
+  },
+]);
+
+root.render(<RouterProvider router={router} />);

--- a/apps/hpc-cdm/src/main.tsx
+++ b/apps/hpc-cdm/src/main.tsx
@@ -13,7 +13,12 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 
 root.render(
-  <BrowserRouter>
+  <BrowserRouter
+    future={{
+      v7_startTransition: true,
+      v7_relativeSplatPath: true,
+    }}
+  >
     <ThemeProvider>
       <App />
     </ThemeProvider>

--- a/apps/hpc-ftsadmin/src/app/app.spec.tsx
+++ b/apps/hpc-ftsadmin/src/app/app.spec.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { ThemeProvider } from '@unocha/hpc-ui';
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import App from './app';
 
 describe('App', () => {

--- a/apps/hpc-ftsadmin/src/app/app.tsx
+++ b/apps/hpc-ftsadmin/src/app/app.tsx
@@ -8,7 +8,7 @@ import {
   ThemeProvider,
 } from '@unocha/hpc-ui';
 import { useEffect, useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import env, { Environment } from '../environments/environment';

--- a/apps/hpc-ftsadmin/src/app/app.tsx
+++ b/apps/hpc-ftsadmin/src/app/app.tsx
@@ -8,7 +8,7 @@ import {
   ThemeProvider,
 } from '@unocha/hpc-ui';
 import { useEffect, useState } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import env, { Environment } from '../environments/environment';
@@ -16,15 +16,8 @@ import { LanguageKey, LANGUAGE_CHOICE, t } from '../i18n';
 import PageMeta from './components/page-meta';
 import { AppContext, contextFromEnv } from './context';
 import { Z_INDEX } from './layout';
-import PageFlowsList from './pages/flows/flows-list';
-import PageKeywordsList from './pages/keywords/keyword-list';
-import PageNotFound from './pages/not-found';
 import PageNotLoggedIn from './pages/not-logged-in';
-import PagePendingFlowsList from './pages/flows/pending-flows-list';
-import PageOrganizationsList from './pages/organizations/organization-list';
-import PageOrganization from './pages/organizations/organization';
 import * as paths from './paths';
-import { RouteParamsValidator } from './components/route-params-validator';
 
 const environmentWarning = (env: Environment, lang: LanguageKey) => {
   const warning = env.getDevHeaderWarning(lang);
@@ -180,42 +173,7 @@ export const App = () => {
                             : []),
                         ]}
                       />
-                      <Routes>
-                        <Route
-                          path={paths.home()}
-                          element={<Navigate to={paths.flows()} />}
-                        />
-                        <Route
-                          path={paths.flows()}
-                          element={<PageFlowsList />}
-                        />
-                        <Route
-                          path={paths.pendingFlows()}
-                          element={<PagePendingFlowsList />}
-                        />
-                        <Route
-                          path={paths.organizations()}
-                          element={<PageOrganizationsList />}
-                        />
-                        <Route
-                          path={paths.organizationRoot()}
-                          element={
-                            <RouteParamsValidator
-                              element={<PageOrganization />}
-                              routeParam="id"
-                            />
-                          }
-                        />
-                        <Route
-                          path={paths.addOrganization()}
-                          element={<PageOrganization />}
-                        />
-                        <Route
-                          path={paths.keywords()}
-                          element={<PageKeywordsList />}
-                        />
-                        <Route element={<PageNotFound />} />
-                      </Routes>
+                      <Outlet />
                     </LoggedInContainer>
                   ) : (
                     <>

--- a/apps/hpc-ftsadmin/src/app/components/organization-form.tsx
+++ b/apps/hpc-ftsadmin/src/app/components/organization-form.tsx
@@ -6,7 +6,7 @@ import { t } from '../../i18n';
 import { AppContext } from '../context';
 import { useContext, useState } from 'react';
 import { organizations, FormObjectValue } from '@unocha/hpc-data';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import * as paths from '../paths';
 import { errors } from '@unocha/hpc-data';
 import { Strings } from '../../i18n/iface';

--- a/apps/hpc-ftsadmin/src/app/components/route-params-validator.tsx
+++ b/apps/hpc-ftsadmin/src/app/components/route-params-validator.tsx
@@ -1,6 +1,6 @@
 import { C } from '@unocha/hpc-ui';
 import { useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { t } from '../../i18n';
 import { AppContext } from '../context';
 

--- a/apps/hpc-ftsadmin/src/app/components/tables/flows-table.tsx
+++ b/apps/hpc-ftsadmin/src/app/components/tables/flows-table.tsx
@@ -54,7 +54,7 @@ import {
   TopRowContainer,
   handleTableSettingsInfoClose,
 } from './table-utils';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import * as paths from '../../paths';
 import { LocalStorageSchema } from '../../utils/local-storage-type';
 import { util } from '@unocha/hpc-core';

--- a/apps/hpc-ftsadmin/src/app/components/tables/organizations-table.tsx
+++ b/apps/hpc-ftsadmin/src/app/components/tables/organizations-table.tsx
@@ -49,7 +49,7 @@ import {
   TopRowContainer,
   handleTableSettingsInfoClose,
 } from './table-utils';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import * as paths from '../../paths';
 import { util } from '@unocha/hpc-core';
 import { LocalStorageSchema } from '../../utils/local-storage-type';

--- a/apps/hpc-ftsadmin/src/app/pages/organizations/organization.tsx
+++ b/apps/hpc-ftsadmin/src/app/pages/organizations/organization.tsx
@@ -3,7 +3,7 @@ import { t } from '../../../i18n';
 import PageMeta from '../../components/page-meta';
 import { AppContext, getEnv } from '../../context';
 import tw from 'twin.macro';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import OrganizationForm, {
   AddEditOrganizationValues,
 } from '../../components/organization-form';

--- a/apps/hpc-ftsadmin/src/app/paths.ts
+++ b/apps/hpc-ftsadmin/src/app/paths.ts
@@ -1,5 +1,6 @@
 const HOME = '/';
 const ROOT = '/*';
+const SPLAT = '*';
 const FLOWS = '/flows';
 const PENDING_FLOWS = '/pending-flows';
 const ORGANIZATIONS = '/organizations';
@@ -18,21 +19,53 @@ const replacePlaceholders = (
   return path;
 };
 
+/**
+ * `/`
+ */
 export const home = () => replacePlaceholders(HOME, {});
 
+/**
+ * `*`
+ */
+export const splat = () => SPLAT;
+
+/**
+ * `/flows`
+ */
 export const flows = () => replacePlaceholders(FLOWS, {});
 
+/**
+ * `/pending-flows`
+ */
 export const pendingFlows = () => replacePlaceholders(PENDING_FLOWS, {});
 
+/**
+ * `/organizations`
+ */
 export const organizations = () => replacePlaceholders(ORGANIZATIONS, {});
 
+/**
+ * `/organizations/:id`
+ */
 export const organization = (id: number) =>
   replacePlaceholders(ORGANIZATION, { id });
 
+/**
+ * `/organizations/:id/*`
+ */
 export const organizationRoot = () => ORGANIZATION + ROOT;
 
+/**
+ * `/organizations/add`
+ */
 export const addOrganization = () => replacePlaceholders(ADD_ORGANIZATION, {});
 
+/**
+ * `/flows/:id`
+ */
 export const flow = (id: number) => replacePlaceholders(FLOW, { id });
 
+/**
+ * `/keywords`
+ */
 export const keywords = () => replacePlaceholders(KEYWORDS, {});

--- a/apps/hpc-ftsadmin/src/libs/useQueryParams.ts
+++ b/apps/hpc-ftsadmin/src/libs/useQueryParams.ts
@@ -1,0 +1,44 @@
+import { useContext } from 'react';
+import {
+  useNavigate,
+  useLocation,
+  UNSAFE_DataRouterContext,
+  UNSAFE_LocationContext,
+} from 'react-router';
+import { type QueryParamAdapter, type PartialLocation } from 'use-query-params';
+
+export const ReactRouter7Adapter = ({
+  children,
+}: {
+  children: (adapter: QueryParamAdapter) => React.ReactElement | null;
+}) => {
+  // we need the navigator directly so we can access the current version
+  // of location in case of multiple updates within a render (e.g. #233)
+  // but we will limit our usage of it and have a backup to just use
+  // useLocation() output in case of some kind of breaking change we miss.
+  // see: https://github.com/remix-run/react-router/blob/f3d87dcc91fbd6fd646064b88b4be52c15114603/packages/react-router-dom/index.tsx#L113-L131
+  const { location: unsafeLocation } = useContext(UNSAFE_LocationContext);
+  const navigate = useNavigate();
+  const router = useContext(UNSAFE_DataRouterContext)?.router;
+  const location = useLocation();
+
+  const adapter: QueryParamAdapter = {
+    replace(location2: PartialLocation) {
+      navigate(location2.search || '?', {
+        replace: true,
+        state: location2.state,
+      });
+    },
+    push(location2: PartialLocation) {
+      navigate(location2.search || '?', {
+        replace: false,
+        state: location2.state,
+      });
+    },
+    get location() {
+      return router?.state?.location ?? unsafeLocation ?? location;
+    },
+  };
+
+  return children(adapter);
+};

--- a/apps/hpc-ftsadmin/src/main.tsx
+++ b/apps/hpc-ftsadmin/src/main.tsx
@@ -1,9 +1,5 @@
 import ReactDOM from 'react-dom/client';
-import {
-  createBrowserRouter,
-  Navigate,
-  RouterProvider,
-} from 'react-router-dom';
+import { createBrowserRouter, Navigate, RouterProvider } from 'react-router';
 
 import App from './app/app';
 
@@ -25,45 +21,32 @@ if (!rootElement) {
 }
 const root = ReactDOM.createRoot(rootElement);
 
-const router = createBrowserRouter(
-  [
-    {
-      path: paths.home(),
-      element: (
-        <QueryParamProvider adapter={ReactRouter6Adapter}>
-          <App />
-        </QueryParamProvider>
-      ),
-      children: [
-        { path: paths.home(), element: <Navigate to={paths.flows()} /> },
-        { path: paths.flows(), element: <PageFlowsList /> },
-        { path: paths.pendingFlows(), element: <PagePendingFlowsList /> },
-        { path: paths.organizations(), element: <PageOrganizationsList /> },
-        {
-          path: paths.organizationRoot(),
-          element: (
-            <RouteParamsValidator
-              element={<PageOrganization />}
-              routeParam="id"
-            />
-          ),
-        },
-        { path: paths.addOrganization(), element: <PageOrganization /> },
-        { path: paths.keywords(), element: <PageKeywordsList /> },
-        { path: paths.splat(), element: <PageNotFound /> },
-      ],
-    },
-  ],
+const router = createBrowserRouter([
   {
-    future: {
-      v7_fetcherPersist: true,
-      v7_normalizeFormMethod: true,
-      v7_partialHydration: true,
-      v7_relativeSplatPath: true,
-      v7_skipActionErrorRevalidation: true,
-    },
-  }
-);
-root.render(
-  <RouterProvider router={router} future={{ v7_startTransition: true }} />
-);
+    path: paths.home(),
+    element: (
+      <QueryParamProvider adapter={ReactRouter6Adapter}>
+        <App />
+      </QueryParamProvider>
+    ),
+    children: [
+      { path: paths.home(), element: <Navigate to={paths.flows()} /> },
+      { path: paths.flows(), element: <PageFlowsList /> },
+      { path: paths.pendingFlows(), element: <PagePendingFlowsList /> },
+      { path: paths.organizations(), element: <PageOrganizationsList /> },
+      {
+        path: paths.organizationRoot(),
+        element: (
+          <RouteParamsValidator
+            element={<PageOrganization />}
+            routeParam="id"
+          />
+        ),
+      },
+      { path: paths.addOrganization(), element: <PageOrganization /> },
+      { path: paths.keywords(), element: <PageKeywordsList /> },
+      { path: paths.splat(), element: <PageNotFound /> },
+    ],
+  },
+]);
+root.render(<RouterProvider router={router} />);

--- a/apps/hpc-ftsadmin/src/main.tsx
+++ b/apps/hpc-ftsadmin/src/main.tsx
@@ -1,9 +1,23 @@
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
-import { QueryParamProvider } from 'use-query-params';
-import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
+import {
+  createBrowserRouter,
+  Navigate,
+  RouterProvider,
+} from 'react-router-dom';
 
 import App from './app/app';
+
+import * as paths from './app/paths';
+import PageFlowsList from './app/pages/flows/flows-list';
+import PageKeywordsList from './app/pages/keywords/keyword-list';
+import PageNotFound from './app/pages/not-found';
+import PagePendingFlowsList from './app/pages/flows/pending-flows-list';
+import PageOrganizationsList from './app/pages/organizations/organization-list';
+import PageOrganization from './app/pages/organizations/organization';
+
+import { RouteParamsValidator } from './app/components/route-params-validator';
+import { QueryParamProvider } from 'use-query-params';
+import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -11,10 +25,32 @@ if (!rootElement) {
 }
 const root = ReactDOM.createRoot(rootElement);
 
-root.render(
-  <BrowserRouter>
-    <QueryParamProvider adapter={ReactRouter6Adapter}>
-      <App />
-    </QueryParamProvider>
-  </BrowserRouter>
-);
+const router = createBrowserRouter([
+  {
+    path: paths.home(),
+    element: (
+      <QueryParamProvider adapter={ReactRouter6Adapter}>
+        <App />
+      </QueryParamProvider>
+    ),
+    children: [
+      { path: paths.home(), element: <Navigate to={paths.flows()} /> },
+      { path: paths.flows(), element: <PageFlowsList /> },
+      { path: paths.pendingFlows(), element: <PagePendingFlowsList /> },
+      { path: paths.organizations(), element: <PageOrganizationsList /> },
+      {
+        path: paths.organizationRoot(),
+        element: (
+          <RouteParamsValidator
+            element={<PageOrganization />}
+            routeParam="id"
+          />
+        ),
+      },
+      { path: paths.addOrganization(), element: <PageOrganization /> },
+      { path: paths.keywords(), element: <PageKeywordsList /> },
+      { path: paths.splat(), element: <PageNotFound /> },
+    ],
+  },
+]);
+root.render(<RouterProvider router={router} />);

--- a/apps/hpc-ftsadmin/src/main.tsx
+++ b/apps/hpc-ftsadmin/src/main.tsx
@@ -1,5 +1,6 @@
 import ReactDOM from 'react-dom/client';
-import { createBrowserRouter, Navigate, RouterProvider } from 'react-router';
+import { createBrowserRouter, Navigate } from 'react-router';
+import { RouterProvider } from 'react-router/dom';
 
 import App from './app/app';
 

--- a/apps/hpc-ftsadmin/src/main.tsx
+++ b/apps/hpc-ftsadmin/src/main.tsx
@@ -14,7 +14,7 @@ import PageOrganization from './app/pages/organizations/organization';
 
 import { RouteParamsValidator } from './app/components/route-params-validator';
 import { QueryParamProvider } from 'use-query-params';
-import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
+import { ReactRouter7Adapter } from './libs/useQueryParams';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -26,7 +26,7 @@ const router = createBrowserRouter([
   {
     path: paths.home(),
     element: (
-      <QueryParamProvider adapter={ReactRouter6Adapter}>
+      <QueryParamProvider adapter={ReactRouter7Adapter}>
         <App />
       </QueryParamProvider>
     ),

--- a/apps/hpc-ftsadmin/src/main.tsx
+++ b/apps/hpc-ftsadmin/src/main.tsx
@@ -25,32 +25,45 @@ if (!rootElement) {
 }
 const root = ReactDOM.createRoot(rootElement);
 
-const router = createBrowserRouter([
+const router = createBrowserRouter(
+  [
+    {
+      path: paths.home(),
+      element: (
+        <QueryParamProvider adapter={ReactRouter6Adapter}>
+          <App />
+        </QueryParamProvider>
+      ),
+      children: [
+        { path: paths.home(), element: <Navigate to={paths.flows()} /> },
+        { path: paths.flows(), element: <PageFlowsList /> },
+        { path: paths.pendingFlows(), element: <PagePendingFlowsList /> },
+        { path: paths.organizations(), element: <PageOrganizationsList /> },
+        {
+          path: paths.organizationRoot(),
+          element: (
+            <RouteParamsValidator
+              element={<PageOrganization />}
+              routeParam="id"
+            />
+          ),
+        },
+        { path: paths.addOrganization(), element: <PageOrganization /> },
+        { path: paths.keywords(), element: <PageKeywordsList /> },
+        { path: paths.splat(), element: <PageNotFound /> },
+      ],
+    },
+  ],
   {
-    path: paths.home(),
-    element: (
-      <QueryParamProvider adapter={ReactRouter6Adapter}>
-        <App />
-      </QueryParamProvider>
-    ),
-    children: [
-      { path: paths.home(), element: <Navigate to={paths.flows()} /> },
-      { path: paths.flows(), element: <PageFlowsList /> },
-      { path: paths.pendingFlows(), element: <PagePendingFlowsList /> },
-      { path: paths.organizations(), element: <PageOrganizationsList /> },
-      {
-        path: paths.organizationRoot(),
-        element: (
-          <RouteParamsValidator
-            element={<PageOrganization />}
-            routeParam="id"
-          />
-        ),
-      },
-      { path: paths.addOrganization(), element: <PageOrganization /> },
-      { path: paths.keywords(), element: <PageKeywordsList /> },
-      { path: paths.splat(), element: <PageNotFound /> },
-    ],
-  },
-]);
-root.render(<RouterProvider router={router} />);
+    future: {
+      v7_fetcherPersist: true,
+      v7_normalizeFormMethod: true,
+      v7_partialHydration: true,
+      v7_relativeSplatPath: true,
+      v7_skipActionErrorRevalidation: true,
+    },
+  }
+);
+root.render(
+  <RouterProvider router={router} future={{ v7_startTransition: true }} />
+);

--- a/libs/hpc-ui/src/lib/components/async-icon-button.tsx
+++ b/libs/hpc-ui/src/lib/components/async-icon-button.tsx
@@ -6,7 +6,7 @@ import tw from 'twin.macro';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import { IconButton, Modal, SvgIconProps, Tooltip } from '@mui/material';
 import { Button } from './button';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 interface AsyncIconButtonProps {
   fnPromise: () => Promise<void | unknown>;

--- a/libs/hpc-ui/src/lib/components/button.tsx
+++ b/libs/hpc-ui/src/lib/components/button.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { IconType } from 'react-icons/lib';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { combineClasses } from '../classes';
 import { styled } from '../theme';

--- a/libs/hpc-ui/src/lib/components/form-fields/async-autocomplete-field.tsx
+++ b/libs/hpc-ui/src/lib/components/form-fields/async-autocomplete-field.tsx
@@ -82,7 +82,7 @@ const AsyncAutocompleteSelect = ({
     return () => {
       active = false;
     };
-  }, [loading, inputValue, isAutocompleteAPI, data, fnPromise]);
+  }, [open, inputValue]);
 
   useEffect(() => {
     if (!open && isAutocompleteAPI) {

--- a/libs/hpc-ui/src/lib/components/list-item.tsx
+++ b/libs/hpc-ui/src/lib/components/list-item.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { CLASSES, combineClasses } from '../classes';
 import Caret from '../assets/icons/caret';
 import { styled } from '../theme';

--- a/libs/hpc-ui/src/lib/components/main-navigation.tsx
+++ b/libs/hpc-ui/src/lib/components/main-navigation.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 
 import {
   List as MUIList,

--- a/libs/hpc-ui/src/lib/components/secondary-navigation.tsx
+++ b/libs/hpc-ui/src/lib/components/secondary-navigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 
 import { CLASSES } from '../classes';
 import { styled } from '../theme';

--- a/libs/hpc-ui/src/lib/components/sidebar-navigation.tsx
+++ b/libs/hpc-ui/src/lib/components/sidebar-navigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import { styled } from '../theme';
 import { IconType } from 'react-icons/lib';
 

--- a/libs/hpc-ui/src/lib/components/tertiary-navigation.tsx
+++ b/libs/hpc-ui/src/lib/components/tertiary-navigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Caret from '../assets/icons/caret';
 
 import { CLASSES } from '../classes';

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "react-is": "18.2.0",
         "react-number-format": "5.4.1",
         "react-refresh": "0.14.0",
-        "react-router-dom": "6.28.0",
+        "react-router": "7.0.2",
         "react-toastify": "9.1.3",
         "styled-components": "5.3.10",
         "tailwindcss": "3.4.10",
@@ -5430,6 +5430,8 @@
       "integrity": "sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -5903,6 +5905,13 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -17624,19 +17633,28 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.0.tgz",
-      "integrity": "sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.2.tgz",
+      "integrity": "sha512-m5AcPfTRUcjwmhBzOJGEl6Y7+Crqyju0+TgTQxoS4SO+BkWbhOrcfZNq6wSWdl2BBbJbsAoBUb8ZacOFT+/JlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.21.0"
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
@@ -17645,6 +17663,8 @@
       "integrity": "sha512-kQ7Unsl5YdyOltsPGl31zOjLrDv+m2VcIEcIHqYYD3Lp0UppLjrzcfJqDJwXxFw3TH/yvapbnUvPlAj7Kx5nbg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.21.0",
         "react-router": "6.28.0"
@@ -17655,6 +17675,34 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom/node_modules/react-router": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.0.tgz",
+      "integrity": "sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@remix-run/router": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/react-side-effect": {
@@ -18393,6 +18441,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -19951,6 +20006,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "react-is": "18.2.0",
     "react-number-format": "5.4.1",
     "react-refresh": "0.14.0",
-    "react-router-dom": "6.28.0",
+    "react-router": "7.0.2",
     "react-toastify": "9.1.3",
     "styled-components": "5.3.10",
     "tailwindcss": "3.4.10",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,7 @@
     "rootDir": ".",
     "sourceMap": true,
     "declaration": false,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,


### PR DESCRIPTION
## Nature of PR

- Bug-fix
- Hot-fix
- Feature
- Testing
- 🟢 Package update
- CI


## Description

[(Link for upgrading documention to v7)](https://reactrouter.com/upgrading/v6)

In this PR we focus on upgrading `react-router-dom` to its newest version `v7.0.2`.During this upgrade this package has been replaced in favor of `react-router`. Of the mentioned necessary changes we had no need to do none of them since they didn't affect us really, except for `v7_startTransition` in `hpc-ftsadmin`. 

In `async-autocomplete-field.tsx` we had an `useEffect()` with the wrong variables inside of the dependency array. We decided to write all of them in order for `eslint` to not raise a warning of used variables in `useEffect()` that were not in the dependency array. After further investigation this extra properties didn't cause a re-render what entered in conflict with `v7_startTransition`, since with this flag `react-router` uses `useTransition()` instead of `useState()` what makes React categorize the importance of an action. The solution I provided, was going to my latest working branch of `hpc-ftsadmin` and took the values that I had in this dependencies array since I already encountered errors on this component and provided a fix.

Beside this change there is another "important" change that is to change the `tsconfig.base.json` and  adding this new module resolution :
```
"moduleResolution": "bundler",
```
We were using `node` that anyways we would have had to update to `node16` or `nodenext` since we support modern versions of Node. But since we used `Nx` and `webpack` I could activate `bundler` mode that give us more flexibility like not having to add all the file extensions of imports what would have resulted in a "big refactor". This was mainly done to allow us to import from `react-router/dom`, while using `node` we could not resolve this import.

I took the opportunity to implement a modern implementation of how they propose to create routers since `v6` in `hpc-ftsadmin` what will allow us to use the data API that will be necessary in the development of FTS Admin v2.

## How to test changes

To test this change I would recommend:

1. Going through the documentation (I provided a link on previous section) and verify the steps that were followed. 
2. Verifying using `"moduleResolution": "bundler"` doesn't raise any problems.
3. That routes didn't break in `hpc-ftsadmin` or `hpc-cdm`.
4. Verify `ReactRouter7Adapter` is well written.

