### PR TITLE
Add workspace setting to not read flat config eslint file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  //  TODO: Remove this setting when upgrading ESLint to v9.0.0 or higher
+  "eslint.useFlatConfig": false
+}


### PR DESCRIPTION
## Description

~~Temporal~~ Temporary solution for `eslint-vscode` to work as expected as long as we are in `eslint v8.54.0`. Without this setting, `hpc_service` `eslint.config.js` interferes with `eslintrc.json` config file of `hpc-cdm`


## TODO:

Upgrade `eslint` to latest `v9` minor version available and remove this newly added setting