### PR TITLE
HPC-10048 Upgrade `react-toastify` to latest version

### DIFF
--- a/apps/hpc-cdm/src/app/app.tsx
+++ b/apps/hpc-cdm/src/app/app.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Outlet } from 'react-router';
 import { ToastContainer } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
 
 import { BaseStyling, C, styled, dataLoader, dialogs } from '@unocha/hpc-ui';
 

--- a/apps/hpc-cdm/src/app/components/enketo/index.tsx
+++ b/apps/hpc-cdm/src/app/components/enketo/index.tsx
@@ -232,7 +232,7 @@ export const EnketoEditableForm = (props: Props) => {
                 lang,
                 (s) => s.routes.operations.forms.status.idle
               );
-              toast.success(msg, { position: toast.POSITION.TOP_RIGHT });
+              toast.success(msg, { position: 'top-right' });
               if (redirect) {
                 if (finalized) {
                   alert(
@@ -268,7 +268,7 @@ export const EnketoEditableForm = (props: Props) => {
                   .t(lang, (s) => s.routes.operations.forms.errors.conflict)
                   .replace('{timeAgo}', timeAgo.fromNow())
                   .replace('{person}', err.otherUser);
-                toast.error(msg, { position: toast.POSITION.TOP_RIGHT });
+                toast.error(msg, { position: 'top-right' });
               } else {
                 setStatus({
                   type: 'error',
@@ -279,7 +279,7 @@ export const EnketoEditableForm = (props: Props) => {
                   (s) => s.routes.operations.forms.status.error
                 );
                 toast.error(`${msg} ${err.message || err.toString()}`, {
-                  position: toast.POSITION.TOP_RIGHT,
+                  position: 'top-right',
                 });
               }
             });

--- a/apps/hpc-ftsadmin/src/app/app.tsx
+++ b/apps/hpc-ftsadmin/src/app/app.tsx
@@ -10,7 +10,6 @@ import {
 import { useEffect, useState } from 'react';
 import { Outlet } from 'react-router';
 import { ToastContainer } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
 import env, { Environment } from '../environments/environment';
 import { LanguageKey, LANGUAGE_CHOICE, t } from '../i18n';
 import PageMeta from './components/page-meta';

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "react-number-format": "5.4.1",
         "react-refresh": "0.14.0",
         "react-router": "7.0.2",
-        "react-toastify": "9.1.3",
+        "react-toastify": "10.0.0",
         "styled-components": "5.3.10",
         "tailwindcss": "3.4.10",
         "ts-jest": "29.1.0",
@@ -3720,16 +3720,6 @@
         }
       }
     },
-    "node_modules/@mui/material/node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@mui/material/node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -3796,17 +3786,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@mui/private-theming/node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@mui/private-theming/node_modules/react-is": {
@@ -3953,17 +3932,6 @@
         }
       }
     },
-    "node_modules/@mui/system/node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@mui/system/node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -4016,16 +3984,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@mui/utils/node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@mui/utils/node_modules/react-is": {
@@ -4099,16 +4057,6 @@
         "moment-jalaali": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@mui/x-date-pickers/node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -8359,10 +8307,11 @@
       }
     },
     "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -17664,12 +17613,13 @@
       }
     },
     "node_modules/react-toastify": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
-      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.0.tgz",
+      "integrity": "sha512-nTKun8snjXcdmaYJIwgeXQ1IKkUBDkCt7O3K1y/XdrFh8o+MZwO1mY79cZ+qsXX92KFz6psUxHUZcLHCVkA/Sw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "clsx": "^1.1.1"
+        "clsx": "^2.1.0"
       },
       "peerDependencies": {
         "react": ">=16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "react-number-format": "5.4.1",
         "react-refresh": "0.14.0",
         "react-router": "7.0.2",
-        "react-toastify": "10.0.0",
+        "react-toastify": "11.0.3",
         "styled-components": "5.3.10",
         "tailwindcss": "3.4.10",
         "ts-jest": "29.1.0",
@@ -17613,17 +17613,17 @@
       }
     },
     "node_modules/react-toastify": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.0.tgz",
-      "integrity": "sha512-nTKun8snjXcdmaYJIwgeXQ1IKkUBDkCt7O3K1y/XdrFh8o+MZwO1mY79cZ+qsXX92KFz6psUxHUZcLHCVkA/Sw==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.3.tgz",
+      "integrity": "sha512-cbPtHJPfc0sGqVwozBwaTrTu1ogB9+BLLjd4dDXd863qYLj7DGrQ2sg5RAChjFUB4yc3w8iXOtWcJqPK/6xqRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "clsx": "^2.1.0"
+        "clsx": "^2.1.1"
       },
       "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "react-number-format": "5.4.1",
     "react-refresh": "0.14.0",
     "react-router": "7.0.2",
-    "react-toastify": "10.0.0",
+    "react-toastify": "11.0.3",
     "styled-components": "5.3.10",
     "tailwindcss": "3.4.10",
     "ts-jest": "29.1.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "react-number-format": "5.4.1",
     "react-refresh": "0.14.0",
     "react-router": "7.0.2",
-    "react-toastify": "9.1.3",
+    "react-toastify": "10.0.0",
     "styled-components": "5.3.10",
     "tailwindcss": "3.4.10",
     "ts-jest": "29.1.0",


### PR DESCRIPTION
## Nature of PR
- Bug-fix
- Hot-fix
- Feature
- Testing
- Rewrite
- CI
- 🟢 Packages


## Description

_For more context please read ticket HPC-10048_

Upgrade `react-toastify` to latest version (to this day `v11.0.3`)


## How to test changes

Verify with the migration guide that all the steps have been checked, In each commit message there is a link to the migration guide for each version
