### PR TITLE
🚀 [Hotfix] Hardcode apps to build

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,15 +20,6 @@ jobs:
       - name: Install NPM Packages
         run: npm ci
 
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        # Production deployments are triggered by push events and not when a pull request
-        # is open, so we cannot use branch names when determining affected apps
-        if: ${{ github.ref_name == 'env/prod' }}
-        uses: nrwl/nx-set-shas@v4
-        with:
-          main-branch-name: 'env/prod'
-          error-on-no-successful-workflow: true
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -52,26 +43,9 @@ jobs:
       - name: Build affected apps
         run: npx nx affected:build
 
-      - name: Get affected apps
-        id: affectedApps
-        run: |
-          if [[ -z "${{ env.NX_BASE }}" ]]; then
-            BASE_REF=${GITHUB_BASE_REF}
-          else
-            BASE_REF=${{ env.NX_BASE }}
-          fi
-
-          if [[ -z "${{ env.NX_HEAD }}" ]]; then
-            HEAD_REF=${GITHUB_HEAD_REF}
-          else
-            HEAD_REF=${{ env.NX_HEAD }}
-          fi
-
-          echo "AFFECTED_APPS=$(npx nx show projects --affected --type app --exclude=*-e2e --base=$BASE_REF --head=$HEAD_REF | xargs | tr ' ' ',')" >> "$GITHUB_OUTPUT"
-
       - uses: UN-OCHA/hpc-actions@develop
         with:
-          apps-to-build: ${{ steps.affectedApps.outputs.AFFECTED_APPS }}
+          apps-to-build: hpc-cdm,hpc-ftsadmin
         env:
           CONFIG_FILE: .github/workflow.config.json
           GITHUB_TOKEN: ${{ secrets.HPC_BOT_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unocha",
-  "version": "1.10.0",
+  "version": "1.10.0-hotfix-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unocha",
-      "version": "1.10.0",
+      "version": "1.10.0-hotfix-1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unocha",
-  "version": "1.10.0",
+  "version": "1.10.0-hotfix-1",
   "license": "Apache-2.0",
   "scripts": {
     "remove-unneeded-deps": "node tools/remove-unneeded-deps.js",


### PR DESCRIPTION
The workflow with action `nrwl/nx-set-shas` has failed on last attempt of production deployment in #492, because it tries to find the last successful production deployment CI run, and since we haven't released in a long time, it has failed, because the last successful run has expired.

During investigation on how to replace the calculation of head and base revisions we can pass to `nx affected`, it was determined that this command will always mark all apps and libraries as affected when we bump the version, since all of them share common `package.json`.

Nx supports individual `package.json` files per-app, but we intentionally took singular `package.json` approach, so it means we'll always release both apps.

Writing a dedicated script which would ignore commits that only bump version when finding affected projects has proved to be a complex task for the benefit it gives, thus we'll likely drop the `apps-to-build` argument passed to our custom GitHub Action and just always build all images under `dockerImages` in `.github/workflow.config.json`