### PR TITLE
HPC-10213: Remove usage of legacy Dockerfile ENV syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ FROM public.ecr.aws/unocha/nginx:stable-beagle
 
 ARG COMMIT_SHA
 ARG TREE_SHA
-ENV HPC_ACTIONS_COMMIT_SHA $COMMIT_SHA
-ENV HPC_ACTIONS_TREE_SHA $TREE_SHA
+ENV HPC_ACTIONS_COMMIT_SHA=$COMMIT_SHA
+ENV HPC_ACTIONS_TREE_SHA=$TREE_SHA
 
 COPY  --from=builder /srv/src/dist/ /var/www/
 COPY  --from=builder /srv/src/env/etc/nginx/http.d/ /etc/nginx/http.d/


### PR DESCRIPTION
The syntax for `ENV` instructions that doesn't use an assignment operator is being phased out. It was deprecated in [this PR](https://github.com/docker/cli/pull/2743).

Legacy syntax: `ENV var value`
Current syntax: `ENV var=value`