### PR TITLE
Update `io-ts` to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "eslint-plugin-react-hooks": "5.2.0",
         "exceljs": "4.4.0",
         "formik": "2.4.6",
-        "fp-ts": "^2.14.0",
+        "fp-ts": "2.16.10",
         "husky": "8.0.3",
         "intl-list-format": "^1.0.3",
         "intl-messageformat": "^10.3.4",
@@ -14522,10 +14522,11 @@
       }
     },
     "node_modules/fp-ts": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.14.0.tgz",
-      "integrity": "sha512-QLagLSYAgMA00pZzUzeksH/78Sd14y7+Gc2A8Yaja3/IpGOFMdm/gYBuDMxYqLsJ58iT5lz+bJb953RAeFfp1A==",
-      "dev": true
+      "version": "2.16.10",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.10.tgz",
+      "integrity": "sha512-vuROzbNVfCmUkZSUbnWSltR1sbheyQbTzug7LB/46fEa1c0EucLeBaCEUE0gF3ZGUGBt9lVUiziGOhhj6K1ORA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fraction.js": {
       "version": "4.3.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "husky": "8.0.3",
         "intl-list-format": "^1.0.3",
         "intl-messageformat": "^10.3.4",
-        "io-ts": "^2.2.20",
+        "io-ts": "2.2.22",
         "jest": "29.7.0",
         "lint-staged": "15.0.2",
         "nx": "20.7.0",
@@ -15630,10 +15630,11 @@
       }
     },
     "node_modules/io-ts": {
-      "version": "2.2.20",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.20.tgz",
-      "integrity": "sha512-Rq2BsYmtwS5vVttie4rqrOCIfHCS9TgpRLFpKQCM1wZBBRY9nWVGmEvm2FnDbSE2un1UE39DvFpTR5UL47YDcA==",
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.22.tgz",
+      "integrity": "sha512-FHCCztTkHoV9mdBsHpocLpdTAfh956ZQcIkWQxxS0U5HT53vtrcuYdQneEJKH6xILaLNzXVl2Cvwtoy8XNN0AA==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "fp-ts": "^2.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "husky": "8.0.3",
     "intl-list-format": "^1.0.3",
     "intl-messageformat": "^10.3.4",
-    "io-ts": "^2.2.20",
+    "io-ts": "2.2.22",
     "jest": "29.7.0",
     "lint-staged": "15.0.2",
     "nx": "20.7.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "eslint-plugin-react-hooks": "5.2.0",
     "exceljs": "4.4.0",
     "formik": "2.4.6",
-    "fp-ts": "^2.14.0",
+    "fp-ts": "2.16.10",
     "husky": "8.0.3",
     "intl-list-format": "^1.0.3",
     "intl-messageformat": "^10.3.4",


### PR DESCRIPTION
> [!NOTE]  
> If rebasing this PR, make sure to update commit SHA in `external/manifest.json` in `hpc_service`, because it uses fc36da370aa721c8a0c0b3fb1ff81cf82c9cb0e8

What I said in https://github.com/UN-OCHA/hpc-api-core/pull/291 about mixing `io-ts` (and `fp-ts`) versions doesn't cause problems, it isn't true. After installing latest version of `hpc-api-core` in `hpc_service`, which updates `io-ts` and `fp-ts` to latest versions, there are ton of problems when doing `npm run check-types` in `hpc_service`. My thinking was that I never saw `io-ts` update cause problems, so I thought versions could mix & match easily, but that isn't the case.

We ensure same version of `io-ts` and `fp-ts` is used by hpc_service and CDM by having a special [install script](https://github.com/UN-OCHA/hpc_service/blob/322f584fe5736cbc8dfe603d612b92fdec307f34/bin/install.sh#L73-L78), which creates a symbolic link for hpc_service to use `io-ts` from CDM `node_modules` directory.

Without the updates from this PR, I got "Found 859 errors in 147 files" when doing `npm run check-types` in `hpc_service` and errors look mostly like common TS errors or like those errors when you had `strict` disabled, then you enabled it. So, it is completely justifiable that we have an install script ensuring same version is used, because those kinds of type errors don't really suggest the problem could be coming from `io-ts`