### PR TITLE
Bump TS lib to ES2022

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Lint affected apps
         run: npm run lint
 
-      - name: Build affected apps
-        run: npx nx affected:build
+      - name: Build all apps
+        run: npx nx run-many --target=build
 
       - uses: UN-OCHA/hpc-actions@develop
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,9 +9,6 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
-        with:
-          # We need to fetch all branches and commits so that Nx affected has a base to compare against.
-          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,7 @@
     "target": "ES2015",
     "module": "esnext",
     "typeRoots": ["node_modules/@types"],
-    "lib": ["ES2021", "dom"],
+    "lib": ["ES2022", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "strict": true,


### PR DESCRIPTION
Our code already used ES2022 feature with `String.prototype.at()`, but the fact that we're not using the right library was masked by package `@types/node` having a polyfill for this method, which [was removed](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72589/commits/1380e73168a48eb3b7933a969bce8cc949ef4560) in v24 of that package.

Also, I've modified CI to now actually try and build both apps, so that we don't fail to catch problems like this during review phase in the future.